### PR TITLE
Fix share promise resolution on focus regain (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The frontend API is designed to closely resemble the Web Share API, making it in
 2. **Sharing Content**
 
    Use the `share()` function with a `ShareData` object to trigger the native dialog. The files field requires an array of `File` objects, which the plugin automatically handles by converting them to Base64 and managing their lifecycle in the backend.
-   Note: on Android and Windows, the promise resolves when the app regains focus after the share UI closes (best-effort). On macOS, the share delegate is used to resolve when the share completes. We may expose a configuration option in the future to let developers choose the resolution behavior (immediate vs. on-focus vs. delayed).
+   Note: on Android and Windows, the promise resolves when the app regains focus after the share UI closes (best-effort). On macOS, the share delegate is used to resolve when the share completes. On iOS, the promise is resolved using the native completion handler (`UIActivityViewController.completionWithItemsHandler`), which provides accurate resolution when sharing completes. We may expose a configuration option in the future to let developers choose the resolution behavior (immediate vs. on-focus vs. delayed).
 
    ```ts
    import { share, canShare } from "@vnidrop/tauri-plugin-share";

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The frontend API is designed to closely resemble the Web Share API, making it in
 2. **Sharing Content**
 
    Use the `share()` function with a `ShareData` object to trigger the native dialog. The files field requires an array of `File` objects, which the plugin automatically handles by converting them to Base64 and managing their lifecycle in the backend.
-   Note: on Android and desktop, the promise resolves when the app regains focus after the share UI closes (best-effort). We may expose a configuration option in the future to let developers choose the resolution behavior (immediate vs. on-focus vs. delayed).
+   Note: on Android and Windows, the promise resolves when the app regains focus after the share UI closes (best-effort). On macOS, the share delegate is used to resolve when the share completes. We may expose a configuration option in the future to let developers choose the resolution behavior (immediate vs. on-focus vs. delayed).
 
    ```ts
    import { share, canShare } from "@vnidrop/tauri-plugin-share";

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The frontend API is designed to closely resemble the Web Share API, making it in
 2. **Sharing Content**
 
    Use the `share()` function with a `ShareData` object to trigger the native dialog. The files field requires an array of `File` objects, which the plugin automatically handles by converting them to Base64 and managing their lifecycle in the backend.
+   Note: on Android and desktop, the promise resolves when the app regains focus after the share UI closes (best-effort). We may expose a configuration option in the future to let developers choose the resolution behavior (immediate vs. on-focus vs. delayed).
 
    ```ts
    import { share, canShare } from "@vnidrop/tauri-plugin-share";

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -16,7 +16,6 @@ Default permissions for the Vnidrop Plugin, all commands can be invoked by defau
 <th>Description</th>
 </tr>
 
-
 <tr>
 <td>
 

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -16,6 +16,7 @@ Default permissions for the Vnidrop Plugin, all commands can be invoked by defau
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/src/platform/focus.rs
+++ b/src/platform/focus.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc,
+    Arc, Mutex, OnceLock,
+};
+use std::time::Duration;
+
+use tauri::{Runtime, Window, WindowEvent};
+
+use crate::Error;
+
+const FOCUS_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+struct FocusWaiter {
+    pending: Mutex<Option<mpsc::Sender<()>>>,
+    listener_registered: AtomicBool,
+}
+
+impl FocusWaiter {
+    fn new() -> Self {
+        Self {
+            pending: Mutex::new(None),
+            listener_registered: AtomicBool::new(false),
+        }
+    }
+}
+
+pub struct FocusWaitHandle {
+    waiter: Arc<FocusWaiter>,
+    rx: mpsc::Receiver<()>,
+}
+
+impl FocusWaitHandle {
+    pub fn wait(self) -> Result<(), Error> {
+        match self.rx.recv_timeout(FOCUS_WAIT_TIMEOUT) {
+            Ok(()) => {}
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {}
+        }
+        clear_pending(&self.waiter);
+        Ok(())
+    }
+
+    pub fn cancel(self) {
+        clear_pending(&self.waiter);
+    }
+}
+
+pub fn begin_focus_wait<R: Runtime>(window: &Window<R>) -> Result<FocusWaitHandle, Error> {
+    let waiter = get_focus_waiter(window)?;
+    ensure_focus_listener(window, waiter.clone());
+
+    let (tx, rx) = mpsc::channel();
+    {
+        let mut pending = waiter
+            .pending
+            .lock()
+            .map_err(|_| Error::NativeApi("Focus wait state poisoned.".to_string()))?;
+        if pending.is_some() {
+            return Err(Error::NativeApi("Share already in progress.".to_string()));
+        }
+        *pending = Some(tx);
+    }
+
+    Ok(FocusWaitHandle { waiter, rx })
+}
+
+fn clear_pending(waiter: &FocusWaiter) {
+    if let Ok(mut pending) = waiter.pending.lock() {
+        *pending = None;
+    }
+}
+
+fn get_focus_waiter<R: Runtime>(window: &Window<R>) -> Result<Arc<FocusWaiter>, Error> {
+    static WAITERS: OnceLock<Mutex<HashMap<String, Arc<FocusWaiter>>>> = OnceLock::new();
+    let waiters = WAITERS.get_or_init(|| Mutex::new(HashMap::new()));
+
+    let mut map = waiters
+        .lock()
+        .map_err(|_| Error::NativeApi("Focus wait registry poisoned.".to_string()))?;
+    Ok(map
+        .entry(window.label().to_string())
+        .or_insert_with(|| Arc::new(FocusWaiter::new()))
+        .clone())
+}
+
+fn ensure_focus_listener<R: Runtime>(window: &Window<R>, waiter: Arc<FocusWaiter>) {
+    if waiter.listener_registered.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    window.on_window_event(move |event| match event {
+        WindowEvent::Focused(true) | WindowEvent::Destroyed => {
+            if let Ok(mut pending) = waiter.pending.lock() {
+                if let Some(tx) = pending.take() {
+                    let _ = tx.send(());
+                }
+            }
+        }
+        _ => {}
+    });
+}

--- a/src/platform/focus.rs
+++ b/src/platform/focus.rs
@@ -10,17 +10,77 @@ use tauri::{Runtime, Window, WindowEvent};
 
 use crate::Error;
 
+const FOCUS_WAIT_GRACE: Duration = Duration::from_millis(250);
 const FOCUS_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum FocusPhase {
+    WaitingForLoss,
+    WaitingForRegain,
+    Completed,
+}
+
+#[derive(Debug)]
+struct FocusState {
+    phase: FocusPhase,
+}
+
+impl FocusState {
+    fn new() -> Self {
+        Self {
+            phase: FocusPhase::WaitingForLoss,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.phase = FocusPhase::WaitingForLoss;
+    }
+
+    fn mark_completed(&mut self) {
+        self.phase = FocusPhase::Completed;
+    }
+
+    fn on_focus_change(&mut self, focused: bool) -> bool {
+        match (self.phase, focused) {
+            (FocusPhase::WaitingForLoss, false) => {
+                self.phase = FocusPhase::WaitingForRegain;
+                false
+            }
+            (FocusPhase::WaitingForRegain, true) => {
+                self.phase = FocusPhase::Completed;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn on_destroyed(&mut self) -> bool {
+        self.phase = FocusPhase::Completed;
+        true
+    }
+
+    fn on_grace_elapsed(&mut self) -> bool {
+        if self.phase == FocusPhase::WaitingForLoss {
+            self.phase = FocusPhase::Completed;
+            return true;
+        }
+        false
+    }
+}
+
 struct FocusWaiter {
+    label: String,
     pending: Mutex<Option<mpsc::Sender<()>>>,
+    state: Mutex<FocusState>,
     listener_registered: AtomicBool,
 }
 
 impl FocusWaiter {
-    fn new() -> Self {
+    fn new(label: String) -> Self {
         Self {
+            label,
             pending: Mutex::new(None),
+            state: Mutex::new(FocusState::new()),
             listener_registered: AtomicBool::new(false),
         }
     }
@@ -62,6 +122,11 @@ pub fn begin_focus_wait<R: Runtime>(window: &Window<R>) -> Result<FocusWaitHandl
         }
         *pending = Some(tx);
     }
+    if let Ok(mut state) = waiter.state.lock() {
+        state.reset();
+    }
+
+    spawn_focus_grace_timer(waiter.clone());
 
     Ok(FocusWaitHandle { waiter, rx })
 }
@@ -70,18 +135,18 @@ fn clear_pending(waiter: &FocusWaiter) {
     if let Ok(mut pending) = waiter.pending.lock() {
         *pending = None;
     }
+    if let Ok(mut state) = waiter.state.lock() {
+        state.mark_completed();
+    }
 }
 
 fn get_focus_waiter<R: Runtime>(window: &Window<R>) -> Result<Arc<FocusWaiter>, Error> {
-    static WAITERS: OnceLock<Mutex<HashMap<String, Arc<FocusWaiter>>>> = OnceLock::new();
-    let waiters = WAITERS.get_or_init(|| Mutex::new(HashMap::new()));
-
-    let mut map = waiters
+    let mut map = focus_waiters()
         .lock()
         .map_err(|_| Error::NativeApi("Focus wait registry poisoned.".to_string()))?;
     Ok(map
         .entry(window.label().to_string())
-        .or_insert_with(|| Arc::new(FocusWaiter::new()))
+        .or_insert_with(|| Arc::new(FocusWaiter::new(window.label().to_string())))
         .clone())
 }
 
@@ -91,13 +156,110 @@ fn ensure_focus_listener<R: Runtime>(window: &Window<R>, waiter: Arc<FocusWaiter
     }
 
     window.on_window_event(move |event| match event {
-        WindowEvent::Focused(true) | WindowEvent::Destroyed => {
-            if let Ok(mut pending) = waiter.pending.lock() {
-                if let Some(tx) = pending.take() {
-                    let _ = tx.send(());
-                }
+        WindowEvent::Focused(focused) => {
+            if should_complete_on_focus(&waiter, *focused) {
+                complete_wait(&waiter);
             }
+        }
+        WindowEvent::Destroyed => {
+            if should_complete_on_destroy(&waiter) {
+                complete_wait(&waiter);
+            }
+            remove_focus_waiter(&waiter.label);
         }
         _ => {}
     });
+}
+
+fn should_complete_on_focus(waiter: &FocusWaiter, focused: bool) -> bool {
+    let mut state = match waiter.state.lock() {
+        Ok(state) => state,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    state.on_focus_change(focused)
+}
+
+fn should_complete_on_destroy(waiter: &FocusWaiter) -> bool {
+    let mut state = match waiter.state.lock() {
+        Ok(state) => state,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    state.on_destroyed()
+}
+
+fn spawn_focus_grace_timer(waiter: Arc<FocusWaiter>) {
+    std::thread::spawn(move || {
+        std::thread::sleep(FOCUS_WAIT_GRACE);
+        let should_complete = {
+            let mut state = match waiter.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            state.on_grace_elapsed()
+        };
+        if should_complete {
+            complete_wait(&waiter);
+        }
+    });
+}
+
+fn complete_wait(waiter: &FocusWaiter) {
+    let sender = match waiter.pending.lock() {
+        Ok(mut pending) => pending.take(),
+        Err(poisoned) => poisoned.into_inner().take(),
+    };
+    if let Some(tx) = sender {
+        let _ = tx.send(());
+    }
+    if let Ok(mut state) = waiter.state.lock() {
+        state.mark_completed();
+    }
+}
+
+fn remove_focus_waiter(label: &str) {
+    if let Ok(mut map) = focus_waiters().lock() {
+        map.remove(label);
+    }
+}
+
+fn focus_waiters() -> &'static Mutex<HashMap<String, Arc<FocusWaiter>>> {
+    static WAITERS: OnceLock<Mutex<HashMap<String, Arc<FocusWaiter>>>> = OnceLock::new();
+    WAITERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FocusPhase, FocusState};
+
+    #[test]
+    fn focus_state_completes_after_loss_and_regain() {
+        let mut state = FocusState::new();
+        assert!(!state.on_focus_change(true));
+        assert!(!state.on_focus_change(false));
+        assert!(!state.on_focus_change(false));
+        assert!(state.on_focus_change(true));
+        assert_eq!(state.phase, FocusPhase::Completed);
+    }
+
+    #[test]
+    fn focus_state_completes_on_destroy() {
+        let mut state = FocusState::new();
+        assert!(state.on_destroyed());
+        assert_eq!(state.phase, FocusPhase::Completed);
+    }
+
+    #[test]
+    fn focus_state_grace_completes_without_focus_loss() {
+        let mut state = FocusState::new();
+        assert!(state.on_grace_elapsed());
+        assert_eq!(state.phase, FocusPhase::Completed);
+    }
+
+    #[test]
+    fn focus_state_grace_does_not_complete_after_loss() {
+        let mut state = FocusState::new();
+        assert!(!state.on_focus_change(false));
+        assert!(!state.on_grace_elapsed());
+        assert_eq!(state.phase, FocusPhase::WaitingForRegain);
+    }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -2,19 +2,126 @@ use crate::models::CanShareResult;
 use crate::state::PluginTempFileManager;
 use crate::{Error, ShareOptions, SharedFile};
 use base64::{engine::general_purpose, Engine as _};
-use objc2::runtime::AnyObject;
+use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{
+    define_class, msg_send,
     rc::{autoreleasepool, Retained},
-    AnyThread,
+    DefinedClass, MainThreadOnly,
 };
-use objc2_app_kit::{NSSharingServicePicker, NSView};
+use objc2_app_kit::{
+    NSSharingService, NSSharingServiceDelegate, NSSharingServicePicker,
+    NSSharingServicePickerDelegate, NSView,
+};
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
-use objc2_foundation::{NSArray, NSObject, NSString, NSURL};
+use objc2_foundation::{
+    NSArray, NSError, NSObject, NSObjectProtocol, NSString, NSURL, MainThreadMarker,
+};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle, WindowHandle};
+use std::cell::RefCell;
+use std::time::Duration;
 use std::{io::Write, path::Path, sync::mpsc};
 use tauri::{Runtime, State, Window};
 use tempfile::{Builder, NamedTempFile};
-use super::focus;
+
+const SHARE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(60);
+
+thread_local! {
+    static ACTIVE_DELEGATES: RefCell<Vec<Retained<SharePickerDelegate>>> = RefCell::new(Vec::new());
+}
+
+#[derive(Default)]
+struct ShareDelegateIvars {
+    completion: RefCell<Option<mpsc::Sender<Result<(), Error>>>>,
+}
+
+define_class!(
+    #[unsafe(super = NSObject)]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = ShareDelegateIvars]
+    struct SharePickerDelegate;
+
+    unsafe impl NSObjectProtocol for SharePickerDelegate {}
+
+    unsafe impl NSSharingServicePickerDelegate for SharePickerDelegate {
+        #[unsafe(method(sharingServicePicker:delegateForSharingService:))]
+        fn sharing_service_picker_delegate_for_sharing_service(
+            &self,
+            _picker: &NSSharingServicePicker,
+            _service: &NSSharingService,
+            _mtm: MainThreadMarker,
+        ) -> Option<Retained<ProtocolObject<dyn NSSharingServiceDelegate>>> {
+            Some(ProtocolObject::from_retained(self.retain()))
+        }
+
+        #[unsafe(method(sharingServicePicker:didChooseSharingService:))]
+        fn sharing_service_picker_did_choose_sharing_service(
+            &self,
+            _picker: &NSSharingServicePicker,
+            service: Option<&NSSharingService>,
+        ) {
+            if service.is_none() {
+                self.complete(Ok(()));
+            }
+        }
+    }
+
+    unsafe impl NSSharingServiceDelegate for SharePickerDelegate {
+        #[unsafe(method(sharingService:didShareItems:))]
+        fn sharing_service_did_share_items(
+            &self,
+            _service: &NSSharingService,
+            _items: &NSArray,
+        ) {
+            self.complete(Ok(()));
+        }
+
+        #[unsafe(method(sharingService:didFailToShareItems:error:))]
+        fn sharing_service_did_fail_to_share_items_error(
+            &self,
+            _service: &NSSharingService,
+            _items: &NSArray,
+            error: &NSError,
+        ) {
+            let message = autoreleasepool(|pool| unsafe {
+                error.localizedDescription().to_str(pool).to_string()
+            });
+            self.complete(Err(Error::NativeApi(format!(
+                "Sharing failed: {}",
+                message
+            ))));
+        }
+    }
+);
+
+impl SharePickerDelegate {
+    fn new(mtm: MainThreadMarker, completion: mpsc::Sender<Result<(), Error>>) -> Retained<Self> {
+        let ivars = ShareDelegateIvars {
+            completion: RefCell::new(Some(completion)),
+        };
+        let this = Self::alloc(mtm).set_ivars(ivars);
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn complete(&self, result: Result<(), Error>) {
+        if let Some(tx) = self.ivars().completion.borrow_mut().take() {
+            let _ = tx.send(result);
+        }
+        remove_active_delegate(self);
+    }
+}
+
+fn remove_active_delegate(delegate: &SharePickerDelegate) {
+    let delegate_ptr = delegate as *const SharePickerDelegate;
+    ACTIVE_DELEGATES.with(|delegates| {
+        let mut list = delegates.borrow_mut();
+        if let Some(pos) = list
+            .iter()
+            .position(|item| Retained::as_ptr(item) == delegate_ptr)
+        {
+            list.remove(pos);
+        }
+    });
+}
 
 pub fn cleanup() -> Result<(), Error> {
     // Temporary file management on macOS is automatic thanks to `NamedTempFile`.
@@ -33,8 +140,8 @@ pub fn share<R: Runtime>(
     options: ShareOptions,
     state: State<'_, PluginTempFileManager>,
 ) -> Result<(), Error> {
-    let focus_wait = focus::begin_focus_wait(&window)?;
-    let (tx, rx) = mpsc::channel();
+    let (setup_tx, setup_rx) = mpsc::channel();
+    let (completion_tx, completion_rx) = mpsc::channel();
     let window_clone = window.clone();
 
     let managed_files = state.inner().managed_files.clone();
@@ -100,6 +207,11 @@ pub fn share<R: Runtime>(
                     )
                 };
 
+                let mtm = MainThreadMarker::new().expect("Main thread marker");
+                let delegate = SharePickerDelegate::new(mtm, completion_tx);
+                ACTIVE_DELEGATES.with(|delegates| delegates.borrow_mut().push(delegate.retain()));
+                picker.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+
                 let bounds = ns_view.bounds();
                 unsafe {
                     picker.showRelativeToRect_ofView_preferredEdge(
@@ -120,21 +232,21 @@ pub fn share<R: Runtime>(
             });
             Ok(())
         })();
-        tx.send(result)
-            .expect("Failed to send result from main thread");
+        let _ = setup_tx.send(result);
     }) {
-        focus_wait.cancel();
         return Err(e.into());
     }
 
-    let share_result = rx.recv()?;
+    let share_result = setup_rx.recv()?;
     if let Err(err) = share_result {
-        focus_wait.cancel();
         return Err(err);
     }
 
-    focus_wait.wait()?;
-    Ok(())
+    match completion_rx.recv_timeout(SHARE_COMPLETION_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(()),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Ok(()),
+    }
 }
 
 /// Retrieves the native `NSView` pointer from the Tauri window, compatible with `raw-window-handle`.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,6 +8,9 @@ mod linux;
 #[cfg(target_os = "linux")]
 pub use self::linux::*;
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod focus;
+
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -210,9 +210,13 @@ pub fn share<R: Runtime>(
         return Err(e.into());
     }
 
-    let share_result = rx
-        .recv()
-        .map_err(|_| Error::NativeApi("Failed to receive result from main thread".to_string()))?;
+    let share_result = match rx.recv() {
+        Ok(result) => result,
+        Err(err) => {
+            focus_wait.cancel();
+            return Err(err.into());
+        }
+    };
     if let Err(err) = share_result {
         focus_wait.cancel();
         return Err(err);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use super::focus;
 use tauri::{Runtime, State, Window};
 use windows::ApplicationModel::DataTransfer::{DataRequestedEventArgs, DataTransferManager};
 use windows::Foundation::Uri;
@@ -55,12 +56,13 @@ pub fn share<R: Runtime>(
     options: ShareOptions,
     state: State<'_, PluginTempFileManager>,
 ) -> Result<(), Error> {
+    let focus_wait = focus::begin_focus_wait(&window)?;
     let (tx, rx) = mpsc::channel();
     let win_clone = window.clone();
 
     let managed_files_arc = state.inner().managed_files.clone();
 
-    window.run_on_main_thread(move || {
+    if let Err(e) = window.run_on_main_thread(move || {
         let options_arc = std::sync::Arc::new(options.clone());
         let result = (|| -> Result<(), Error> {
             initialize_winrt_thread()?;
@@ -196,14 +198,28 @@ pub fn share<R: Runtime>(
                 *state.borrow_mut() = Some((dtm, token));
             });
 
+            // Best-effort note: ShowShareUIForWindow doesn't provide a reliable completion callback
+            // for desktop apps. Consider making resolution behavior configurable for end developers
+            // (immediate vs. on-focus vs. delayed).
             unsafe { interop.ShowShareUIForWindow(hwnd) }?;
             Ok(())
         })();
         tx.send(result).ok();
-    })?;
+    }) {
+        focus_wait.cancel();
+        return Err(e.into());
+    }
 
-    rx.recv()
-        .map_err(|_| Error::NativeApi("Failed to receive result from main thread".to_string()))?
+    let share_result = rx
+        .recv()
+        .map_err(|_| Error::NativeApi("Failed to receive result from main thread".to_string()))?;
+    if let Err(err) = share_result {
+        focus_wait.cancel();
+        return Err(err);
+    }
+
+    focus_wait.wait()?;
+    Ok(())
 }
 
 /// Initializes the Windows Runtime on the current thread.


### PR DESCRIPTION
Fixes #5.

The share promise now resolves only after the app regains focus (best‑effort) on Android and desktop. This prevents temporary files from being deleted while the share UI is open or the user is in the target app. A timeout fallback avoids hanging if focus never returns.
